### PR TITLE
Fix: requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 cython
 bezier
-python==3.7
 pycocotools
 submitit
 torch>=1.5.0


### PR DESCRIPTION
In the process of setting the environment as shown [here](https://github.com/bytedance/SPTSv2#environment), an error like the picture attached below occurred.

![image](https://github.com/bytedance/SPTSv2/assets/42334717/8e274d3f-e484-4840-b074-81889b6c9f57)

It caused by `python==3.7` in `requirements.txt`

So, I send PR by deleting that line.